### PR TITLE
Translation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,17 @@
 2015-06-15  Diffeo  <support@diffeo.com>
 
 	* Implemented translation of selected text snippets.
-	  Further work required to enable/disable the translation toolbar
-	  button depending on whether a text selection exists; currently
-	  the button is always enabled.
+
+	Further work required to enable/disable the translation toolbar
+	button depending on whether a text selection exists; currently the
+	button is always enabled.
+
+	The translation service is made available after it has been
+	suitably configured.  Configuring the translation service can be
+	achieved by accessing the extension's options/preferences window
+	(for Chrome and Firefox, respectively) and selecting the desired
+	translation service and pasting the API key string.  Presently
+	only the Google Translate service is available.
 
 2015-06-03  Diffeo  <support@diffeo.com>
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+2015-06-15  Diffeo  <support@diffeo.com>
+
+	* Implemented translation of selected text snippets.
+	  Further work required to enable/disable the translation toolbar
+	  button depending on whether a text selection exists; currently
+	  the button is always enabled.
+
+2015-06-03  Diffeo  <support@diffeo.com>
+
+	* Recommendations list can now be sorted and filtered.
+
+	* Several improvements to facets display and UI.
+
 2015-06-01  Diffeo  <support@diffeo.com>
 
 	* Implemented filtering by facets.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,9 @@
 	translation service and pasting the API key string.  Presently
 	only the Google Translate service is available.
 
+	* Improvements to extension sidebar and preferences page in
+	Firefox
+
 2015-06-03  Diffeo  <support@diffeo.com>
 
 	* Recommendations list can now be sorted and filtered.

--- a/sh/update-deps
+++ b/sh/update-deps
@@ -103,6 +103,7 @@ mkdirx shared
 cpx "$dir_src/sorting-common/sorting_common.js" lib/sorting-common/
 cpx "$dir_src/sorting-queue/sorting_queue.js" lib/sorting-queue/
 cpx "$dir_src/sorting-desk/sorting_desk.js" lib/sorting-desk/
+cpx "$dir_src/sorting-desk/translation.js" lib/sorting-desk/
 cpx "$dir_src/sorting-desk/api-live.js" lib/sorting-desk/
 
 # dossier.js

--- a/src/browser/extensions/chrome/lib/sorting-desk/sorting_desk.js
+++ b/src/browser/extensions/chrome/lib/sorting-desk/sorting_desk.js
@@ -1,5 +1,5 @@
 /**
- * @file Sorting Desk component.
+ * @file Sorting Desk main component.
  * @copyright 2015 Diffeo
  *
  * Comments:
@@ -134,6 +134,7 @@
     get constructor ()   { return this.constructor_; },
     get callbacks ()     { return this.callbacks_; },
     get networkFailure() { return this.networkFailure_; },
+    get translator()     { return this.translator_; },
     get events ()        { return this.events_; },
     get api ()           { return this.api_; },
     get resetting ()     { return this.sortingQueue_.resetting(); },
@@ -180,6 +181,7 @@
           remove: finder.find('toolbar-remove'),
           rename: finder.find('toolbar-rename'),
           jump: finder.find('toolbar-jump'),
+          translate: finder.find('toolbar-translate'),
           refresh: {
             explorer: finder.find('toolbar-refresh-explorer'),
             search: finder.find('toolbar-refresh-search')
@@ -228,6 +230,14 @@
                                this.callbacks_,
                                this.options.renderer);
 
+      (this.translator_ = new translation.Controller(
+        this.explorer_,
+        this.callbacks_,
+        {
+          button: els.toolbar.translate,
+          service: this.options.translation
+        } )).initialise();
+
       this.initialised_ = true;
       console.info("Sorting Desk UI initialised");
     },
@@ -245,10 +255,12 @@
       var self = this;
 
       this.explorer_.reset();
+      this.translator_.reset();
 
       return this.sortingQueue_.reset()
         .done(function () {
           self.explorer_ = self.options_ = self.sortingQueue_ = null;
+          self.translator_ = null;
           self.initialised_ = false;
 
           console.info("Sorting Desk UI reset");
@@ -1362,7 +1374,7 @@
         deferred.reject();
       else
         deferred.resolve(result);
-    } );
+    } ).fail(function () { deferred.reject(); } );
 
     return deferred.promise();
   };
@@ -2727,7 +2739,11 @@
   return {
     Sorter: Sorter,
     ControllerExplorer: ControllerExplorer,
-    NetworkFailure: NetworkFailure
+    NetworkFailure: NetworkFailure,
+    Folder: Folder,
+    Subfolder: Subfolder,
+    ItemText: ItemText,
+    ItemImage: ItemImage
   };
 
 }, this);

--- a/src/browser/extensions/chrome/lib/sorting-desk/translation.js
+++ b/src/browser/extensions/chrome/lib/sorting-desk/translation.js
@@ -216,9 +216,8 @@
       console.info("Translating: ", selection.content);
       self.service.translate(selection.content)
         .done(function (response) {
-          console.log("All ok!: ", response);
+          console.log("Translation: ", response);
           selection.content = response;
-          return;
           subfolder.add(selection);
         } )
         .fail(function () {
@@ -226,6 +225,9 @@
           console.error("Translation failed");
         } )
         .always(function () { self.enable_(); } );
+    } ).fail(function () {
+      window.alert("Unable to translate text.  Please ensure text is currently"
+                   + " selected in the active tab");
     } ).always(function () { self.enable_(); } );
   };
 

--- a/src/browser/extensions/chrome/lib/sorting-desk/translation.js
+++ b/src/browser/extensions/chrome/lib/sorting-desk/translation.js
@@ -71,6 +71,7 @@
     if(!std.is_str(options.key) || options.key.length === 0)
       throw "API key not specified";
     this.key = options.key;
+    this.useJsonp = options.useJsonp === true;
   };
   translation.Factory.register('google', translation.ServiceGoogle);
 
@@ -87,10 +88,15 @@
     return url + '?key=' + this.key + '&q=' + encodeURIComponent(query);
   };
 
+  translation.ServiceGoogle.prototype.query = function (url)
+  {
+    return $.ajax( { url: url, dataType: this.useJsonp ? "jsonp" : "json" } );
+  };
+
   translation.ServiceGoogle.prototype.detect = function (query)
   {
     var url = this.url(query, 'detect');
-    return $.getJSON(url).then(function (response) {
+    return this.query(url).then(function (response) {
       return $.Deferred(function (deferred) {
         if(!std.is_obj(response.data)
            || !std.is_arr(response.data.detections)
@@ -133,7 +139,7 @@
     else if(!std.is_str(tgt)) throw "Invalid or no target language specified";
     url += '&source=' + src + '&target=' + tgt;
 
-    return $.getJSON(url).then(function (response) {
+    return this.query(url).then(function (response) {
       return $.Deferred(function (deferred) {
         if(!std.is_obj(response.data)
            || !std.is_arr(response.data.translations)
@@ -212,6 +218,7 @@
         .done(function (response) {
           console.log("All ok!: ", response);
           selection.content = response;
+          return;
           subfolder.add(selection);
         } )
         .fail(function () {

--- a/src/browser/extensions/chrome/lib/sorting-desk/translation.js
+++ b/src/browser/extensions/chrome/lib/sorting-desk/translation.js
@@ -1,0 +1,234 @@
+/**
+ * @file Translation component.
+ * @copyright 2015 Diffeo
+ *
+ * Comments:
+ * Uses the `SortingCommon´ component.
+ *
+ */
+
+
+/*global $, define */
+/*jshint laxbreak:true */
+
+
+(function (factory, root) {
+
+  /* Compatibility with RequireJs. */
+  if(typeof define === "function" && define.amd) {
+    var deps = [ "jquery", "SortingCommon", "SortingDesk" ];
+    define("sorting_desk-translation", deps, function ($, std, sd) {
+      return factory(root, $, std, sd);
+    } );
+  } else
+    root.translation = factory(root, $, SortingCommon, SortingDesk);
+
+} )(function (window, $, std, sd, undefined) {
+
+
+  /* component namespace */
+  var translation = { };
+
+
+  /**
+   * @class
+   * */
+  translation.Factory = {
+    services: {},
+
+    construct: function (options)
+    {
+      var Cl = this.services[options.api];
+      if(!std.is_fn(Cl))
+        throw "Invalid, no API name specified or API not found";
+
+      return new Cl(options);
+    },
+
+    register: function (name, Cl)
+    {
+      if(!std.is_fn(Cl)) throw "Invalid or no constructor specified";
+      this.services[name] = Cl;
+    }
+  };
+
+
+  /**
+   * @class
+   * */
+  translation.Service = function () {};
+  translation.Service.prototype.detect = std.absm_noti;
+  translation.Service.prototype.translate = std.absm_noti;
+
+  translation.Service.DEFAULT_TARGET = 'en';
+
+
+  /**
+   * @class
+   * */
+  translation.ServiceGoogle = function (options)
+  {
+    if(!std.is_str(options.key) || options.key.length === 0)
+      throw "API key not specified";
+    this.key = options.key;
+  };
+  translation.Factory.register('google', translation.ServiceGoogle);
+
+  translation.ServiceGoogle.URL_BASE
+    = 'https://www.googleapis.com/language/translate/v2';
+
+  translation.ServiceGoogle.prototype
+    = Object.create(translation.Service.prototype);
+
+  translation.ServiceGoogle.prototype.url = function (query, endpoint)
+  {
+    var url = translation.ServiceGoogle.URL_BASE;
+    if(endpoint) url += '/' + endpoint;
+    return url + '?key=' + this.key + '&q=' + encodeURIComponent(query);
+  };
+
+  translation.ServiceGoogle.prototype.detect = function (query)
+  {
+    var url = this.url(query, 'detect');
+    return $.getJSON(url).then(function (response) {
+      return $.Deferred(function (deferred) {
+        if(!std.is_obj(response.data)
+           || !std.is_arr(response.data.detections)
+           || response.data.detections.length === 0
+           || response.data.detections[0].length === 0) {
+          deferred.reject();
+        }
+
+        response.data.detections[0].sort(function (l, r) {
+          if(l.confidence < r.confidence)      return -1;
+          else if(l.confidence > r.confidence) return 1;
+          return 0;
+        } );
+
+        deferred.resolve(response.data.detections[0][0].language);
+      } ).promise();
+    } );
+  };
+
+  translation.ServiceGoogle.prototype.translate
+    = function (query, /* optional */ tgt, src)
+  {
+    var self = this;
+
+    if(!std.is_str(tgt)) tgt = translation.Service.DEFAULT_TARGET;
+
+    if(!std.is_str(src)) {
+      return this.detect(query)
+        .then(function (src) { return self.translateEx(query, tgt, src); } );
+    }
+
+    return this.translateEx(query, tgt, src);
+  };
+
+  translation.ServiceGoogle.prototype.translateEx = function (query, tgt, src)
+  {
+    var url = this.url(query);
+
+    if(!std.is_str(src))      throw "Invalid or no source language specified";
+    else if(!std.is_str(tgt)) throw "Invalid or no target language specified";
+    url += '&source=' + src + '&target=' + tgt;
+
+    return $.getJSON(url).then(function (response) {
+      return $.Deferred(function (deferred) {
+        if(!std.is_obj(response.data)
+           || !std.is_arr(response.data.translations)
+           || response.data.translations.length === 0) {
+          deferred.reject();
+        }
+
+        deferred.resolve(response.data.translations[0].translatedText);
+      } ).promise();
+    } );
+  };
+
+
+  /**
+   * @class
+   * */
+  translation.Controller = function (explorer, callbacks, options)
+  {
+    std.Controller.call(this, explorer);
+
+    this.processing = false;
+    this.$button = options.button;
+    this.explorer = explorer;
+    this.callbacks = callbacks;
+
+    try {
+      this.service = std.is_obj(options.service)
+        ? translation.Factory.construct(options.service)
+        : null;
+    } catch(x) { console.info("Translation service unavailable"); }
+  };
+
+  translation.Controller.prototype = Object.create(std.Controller.prototype);
+
+  translation.Controller.prototype.initialise = function ()
+  {
+    if(!this.service) {
+      this.$button.addClass('disabled');
+      return;
+    }
+
+    this.$button.on("click", this.onClick.bind(this));
+  };
+
+  translation.Controller.prototype.reset = function ()
+  {
+    this.processing = false;
+    this.$button.off("click");
+    this.$button = this.service = null;
+  };
+
+  translation.Controller.prototype.onClick = function ()
+  {
+    var subfolder = this.explorer.selected;
+
+    if(this.processing) return;
+    else if(!(subfolder instanceof sd.Subfolder)) {
+      window.alert("Please select a subfolder to add the translated"
+                   + " text item to.");
+      return;
+    }
+
+    this.$button.addClass('disabled');
+    this.processing = true;
+
+    var self = this;
+    this.explorer.get_selection_().done(function (selection) {
+      if(selection.type !== "text") {
+        console.info("Selection type not supported: %s", selection.type);
+        self.enable_();
+        return;
+      }
+
+      console.info("Translating: ", selection.content);
+      self.service.translate(selection.content)
+        .done(function (response) {
+          console.log("All ok!: ", response);
+          selection.content = response;
+          subfolder.add(selection);
+        } )
+        .fail(function () {
+          window.alert("Text translation failed.");
+          console.error("Translation failed");
+        } )
+        .always(function () { self.enable_(); } );
+    } ).always(function () { self.enable_(); } );
+  };
+
+  translation.Controller.prototype.enable_ = function ()
+  {
+    this.processing = false;
+    this.$button.removeClass('disabled');
+  };
+
+
+  return translation;
+
+}, this);

--- a/src/browser/extensions/chrome/src/html/options.html
+++ b/src/browser/extensions/chrome/src/html/options.html
@@ -51,7 +51,7 @@
                 <span class="sr-only">Toggle Dropdown</span>
               </button>
               <ul class="dropdown-menu" aria-labelledby="translation-api">
-                <li data-value="google"><a href="#">Google</a></li>
+                <li data-value="google"><a href="#">Google Translate</a></li>
               </ul>
             </div>
           </div>

--- a/src/browser/extensions/chrome/src/html/options.html
+++ b/src/browser/extensions/chrome/src/html/options.html
@@ -20,15 +20,15 @@
       </div>
       <div class="panel-body form-horizontal">
         <div class="form-group">
-          <label for="dossier-urls" class="col-sm-2 control-label">Dossier stack URL(s)</label>
-          <div class="col-sm-10">
+          <label for="dossier-urls" class="col-sm-3 control-label">Dossier stack URL(s)</label>
+          <div class="col-sm-9">
             <input type="url" class="form-control" id="dossier-urls" placeholder="Enter a valid URL or leave blank to use default" />
           </div>
         </div>
 
         <div class="form-group">
-          <label for="active-url" class="col-sm-2 control-label">Active URL</label>
-          <div class="class-sm-offset-2 col-sm-10">
+          <label for="active-url" class="col-sm-3 control-label">Active URL</label>
+          <div class="class-sm-offset-3 col-sm-9">
             <div class="btn-group">
               <button id="active-url" type="button" class="btn btn-default">Select active Dossier stack URL</button>
               <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
@@ -42,7 +42,30 @@
         </div>
 
         <div class="form-group">
-          <div class="col-sm-offset-2 col-sm-10">
+          <label for="translation-api" class="col-sm-3 control-label">Translation service</label>
+          <div class="class-sm-offset-3 col-sm-9">
+            <div class="btn-group">
+              <button id="translation-api" type="button" class="btn btn-default">Select API service</button>
+              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                <span class="caret"></span>
+                <span class="sr-only">Toggle Dropdown</span>
+              </button>
+              <ul class="dropdown-menu" aria-labelledby="translation-api">
+                <li data-value="google"><a href="#">Google</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="dossier-urls" class="col-sm-3 control-label">Translation API key</label>
+          <div class="col-sm-9">
+            <input type="text" class="form-control" id="translation-key" placeholder="Paste translation API key here" />
+          </div>
+        </div>
+
+        <div class="form-group">
+          <div class="col-sm-offset-3 col-sm-9">
             <div class="checkbox">
               <label>
                 <input id="active" type="checkbox"> Sorting Desk active
@@ -52,8 +75,8 @@
         </div>
 
         <div class="form-group">
-          <label for="start-position" class="col-sm-2 control-label">Start position</label>
-          <div class="class-sm-offset-2 col-sm-10">
+          <label for="start-position" class="col-sm-3 control-label">Start position</label>
+          <div class="class-sm-offset-3 col-sm-9">
             <div class="btn-group">
               <button id="start-position" type="button" class="btn btn-default">Select start position</button>
               <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
@@ -69,7 +92,7 @@
         </div>
 
         <div class="form-group">
-          <div class="col-sm-offset-2 col-sm-10">
+          <div class="col-sm-offset-3 col-sm-9">
             <button id="save" type="submit" class="btn btn-primary">Save</button>
           </div>
         </div>

--- a/src/browser/extensions/chrome/src/html/sidebar.html
+++ b/src/browser/extensions/chrome/src/html/sidebar.html
@@ -27,6 +27,7 @@
   <!-- Sorting Desk -->
   <script src="../../lib/sorting-desk/api-live.js"></script>
   <script src="../../lib/sorting-desk/sorting_desk.js"></script>
+  <script src="../../lib/sorting-desk/translation.js"></script>
   <!-- Sorting Desk: components -->
   <script src="../js/sidebar.js"></script>
 
@@ -85,6 +86,11 @@
           </button>
           <button type="button" class="btn btn-default disabled" data-toggle="tooltip" data-placement="bottom" title="Navigate to bookmarked page" data-sd-scope="sorting-desk-toolbar-jump">
             <span class="glyphicon glyphicon-eye-open"></span>
+          </button>
+        </div>
+        <div class="btn-group btn-group-xs">
+          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Translate selected text" data-sd-scope="sorting-desk-toolbar-translate">
+            <span class="glyphicon glyphicon-comment"></span>
           </button>
         </div>
         <div class="btn-group btn-group-xs">

--- a/src/browser/extensions/chrome/src/js/config.js
+++ b/src/browser/extensions/chrome/src/js/config.js
@@ -17,8 +17,10 @@ var Config = (function (window, chrome, $, std, undefined) {
                    'dev@http://54.174.195.250:8080',
                    'local@http://localhost:8080' ].join(', '),
     activeUrl: 'memex',
-    translationApi: 'google',
-    translationKey: null,
+    translation: {
+      api: 'google',
+      key: null
+    },
     active: true,
     startPosition: 0
   };

--- a/src/browser/extensions/chrome/src/js/config.js
+++ b/src/browser/extensions/chrome/src/js/config.js
@@ -17,6 +17,8 @@ var Config = (function (window, chrome, $, std, undefined) {
                    'dev@http://54.174.195.250:8080',
                    'local@http://localhost:8080' ].join(', '),
     activeUrl: 'memex',
+    translationApi: 'google',
+    translationKey: null,
     active: true,
     startPosition: 0
   };
@@ -93,11 +95,9 @@ var Config = (function (window, chrome, $, std, undefined) {
       state.config = $.extend(true, { },
                               $.extend(true, { }, defaults_),
                               state.config || { });
-      if(!exists)
-        save(state.config);
 
-      if(callback)
-        callback(state.config);
+      if(!exists)  save(state.config);
+      if(callback) callback(state.config);
     } );
   };
 
@@ -110,8 +110,7 @@ var Config = (function (window, chrome, $, std, undefined) {
     chrome.storage.local.set( { "config": options }, function () {
       console.log("Configuration saved");
 
-      if(std.is_fn(callback))
-        callback();
+      if(std.is_fn(callback)) callback();
 
       /* Instruct background to reload extension window. */
       chrome.runtime.sendMessage( { operation: "config-saved" } );

--- a/src/browser/extensions/chrome/src/js/config.js.testing
+++ b/src/browser/extensions/chrome/src/js/config.js.testing
@@ -15,6 +15,8 @@ var Config = (function (window, chrome, $, std, undefined) {
   var defaults_ = {
     dossierUrls: 'local@http://localhost:8001',
     activeUrl: 'local',
+    translationApi: 'google',
+    translationKey: null,
     active: true,
     startPosition: 0
   };

--- a/src/browser/extensions/chrome/src/js/options.js
+++ b/src/browser/extensions/chrome/src/js/options.js
@@ -25,6 +25,8 @@ var Options = (function (window, $, std, undefined) {
         Config.save( {
           dossierUrls: $('#dossier-urls').val(),
           activeUrl: $('#active-url').val(),
+          translationApi: $('#translation-api').val(),
+          translationKey: $('#translation-key').val(),
           active: $('#active').is(':checked'),
           startPosition: $('#start-position').val()
         } );
@@ -115,17 +117,17 @@ var Options = (function (window, $, std, undefined) {
       updateActiveUrl_();
 
       $('#active').prop('checked', state.active);
-      setDropdownValue_($('#start-position'), state.startPosition, 0);
       setDropdownValue_($('#active-url'), state.activeUrl);
+      setDropdownValue_($('#translation-api'), state.translationApi);
+      $('#translation-key').val(state.translationKey);
+      setDropdownValue_($('#start-position'), state.startPosition, 0);
 
-      if(std.is_fn(callback))
-        callback();
+      if(std.is_fn(callback)) callback();
     } );
   };
 
 
   /* Initialize options page controller. */
-  $(function () {
-    initialise_();
-  } );
+  $(function () { initialise_(); } );
+
 })(window, $, SortingCommon);

--- a/src/browser/extensions/chrome/src/js/options.js
+++ b/src/browser/extensions/chrome/src/js/options.js
@@ -25,8 +25,10 @@ var Options = (function (window, $, std, undefined) {
         Config.save( {
           dossierUrls: $('#dossier-urls').val(),
           activeUrl: $('#active-url').val(),
-          translationApi: $('#translation-api').val(),
-          translationKey: $('#translation-key').val(),
+          translation: {
+            api: $('#translation-api').val(),
+            key: $('#translation-key').val()
+          },
           active: $('#active').is(':checked'),
           startPosition: $('#start-position').val()
         } );
@@ -118,8 +120,8 @@ var Options = (function (window, $, std, undefined) {
 
       $('#active').prop('checked', state.active);
       setDropdownValue_($('#active-url'), state.activeUrl);
-      setDropdownValue_($('#translation-api'), state.translationApi);
-      $('#translation-key').val(state.translationKey);
+      setDropdownValue_($('#translation-api'), state.translation.api);
+      $('#translation-key').val(state.translation.key);
       setDropdownValue_($('#start-position'), state.startPosition, 0);
 
       if(std.is_fn(callback)) callback();

--- a/src/browser/extensions/chrome/src/js/sidebar.js
+++ b/src/browser/extensions/chrome/src/js/sidebar.js
@@ -458,6 +458,10 @@ var Main = (function (window, chrome, $, std, sq, sqc, sd, undefined) {
     (sorter = new sd.Sorter( {
       container: $('#sd-folder-explorer'),
       dossierUrl: meta.config.activeUrl,
+      translation: {
+        api: meta.config.translationApi,
+        key: meta.config.translationKey
+      },
       sortingQueue: {
         options: {
           container: $('#sd-queue'),

--- a/src/browser/extensions/chrome/src/js/sidebar.js
+++ b/src/browser/extensions/chrome/src/js/sidebar.js
@@ -459,8 +459,8 @@ var Main = (function (window, chrome, $, std, sq, sqc, sd, undefined) {
       container: $('#sd-folder-explorer'),
       dossierUrl: meta.config.activeUrl,
       translation: {
-        api: meta.config.translationApi,
-        key: meta.config.translationKey
+        api: meta.config.translation.api,
+        key: meta.config.translation.key
       },
       sortingQueue: {
         options: {

--- a/src/browser/extensions/firefox/data/lib/sorting-desk/sorting_desk.js
+++ b/src/browser/extensions/firefox/data/lib/sorting-desk/sorting_desk.js
@@ -1,5 +1,5 @@
 /**
- * @file Sorting Desk component.
+ * @file Sorting Desk main component.
  * @copyright 2015 Diffeo
  *
  * Comments:
@@ -134,6 +134,7 @@
     get constructor ()   { return this.constructor_; },
     get callbacks ()     { return this.callbacks_; },
     get networkFailure() { return this.networkFailure_; },
+    get translator()     { return this.translator_; },
     get events ()        { return this.events_; },
     get api ()           { return this.api_; },
     get resetting ()     { return this.sortingQueue_.resetting(); },
@@ -180,6 +181,7 @@
           remove: finder.find('toolbar-remove'),
           rename: finder.find('toolbar-rename'),
           jump: finder.find('toolbar-jump'),
+          translate: finder.find('toolbar-translate'),
           refresh: {
             explorer: finder.find('toolbar-refresh-explorer'),
             search: finder.find('toolbar-refresh-search')
@@ -228,6 +230,14 @@
                                this.callbacks_,
                                this.options.renderer);
 
+      (this.translator_ = new translation.Controller(
+        this.explorer_,
+        this.callbacks_,
+        {
+          button: els.toolbar.translate,
+          service: this.options.translation
+        } )).initialise();
+
       this.initialised_ = true;
       console.info("Sorting Desk UI initialised");
     },
@@ -245,10 +255,12 @@
       var self = this;
 
       this.explorer_.reset();
+      this.translator_.reset();
 
       return this.sortingQueue_.reset()
         .done(function () {
           self.explorer_ = self.options_ = self.sortingQueue_ = null;
+          self.translator_ = null;
           self.initialised_ = false;
 
           console.info("Sorting Desk UI reset");
@@ -1362,7 +1374,7 @@
         deferred.reject();
       else
         deferred.resolve(result);
-    } );
+    } ).fail(function () { deferred.reject(); } );
 
     return deferred.promise();
   };
@@ -2727,7 +2739,11 @@
   return {
     Sorter: Sorter,
     ControllerExplorer: ControllerExplorer,
-    NetworkFailure: NetworkFailure
+    NetworkFailure: NetworkFailure,
+    Folder: Folder,
+    Subfolder: Subfolder,
+    ItemText: ItemText,
+    ItemImage: ItemImage
   };
 
 }, this);

--- a/src/browser/extensions/firefox/data/lib/sorting-desk/translation.js
+++ b/src/browser/extensions/firefox/data/lib/sorting-desk/translation.js
@@ -216,9 +216,8 @@
       console.info("Translating: ", selection.content);
       self.service.translate(selection.content)
         .done(function (response) {
-          console.log("All ok!: ", response);
+          console.log("Translation: ", response);
           selection.content = response;
-          return;
           subfolder.add(selection);
         } )
         .fail(function () {
@@ -226,6 +225,9 @@
           console.error("Translation failed");
         } )
         .always(function () { self.enable_(); } );
+    } ).fail(function () {
+      window.alert("Unable to translate text.  Please ensure text is currently"
+                   + " selected in the active tab");
     } ).always(function () { self.enable_(); } );
   };
 

--- a/src/browser/extensions/firefox/data/lib/sorting-desk/translation.js
+++ b/src/browser/extensions/firefox/data/lib/sorting-desk/translation.js
@@ -1,0 +1,241 @@
+/**
+ * @file Translation component.
+ * @copyright 2015 Diffeo
+ *
+ * Comments:
+ * Uses the `SortingCommon´ component.
+ *
+ */
+
+
+/*global $, define */
+/*jshint laxbreak:true */
+
+
+(function (factory, root) {
+
+  /* Compatibility with RequireJs. */
+  if(typeof define === "function" && define.amd) {
+    var deps = [ "jquery", "SortingCommon", "SortingDesk" ];
+    define("sorting_desk-translation", deps, function ($, std, sd) {
+      return factory(root, $, std, sd);
+    } );
+  } else
+    root.translation = factory(root, $, SortingCommon, SortingDesk);
+
+} )(function (window, $, std, sd, undefined) {
+
+
+  /* component namespace */
+  var translation = { };
+
+
+  /**
+   * @class
+   * */
+  translation.Factory = {
+    services: {},
+
+    construct: function (options)
+    {
+      var Cl = this.services[options.api];
+      if(!std.is_fn(Cl))
+        throw "Invalid, no API name specified or API not found";
+
+      return new Cl(options);
+    },
+
+    register: function (name, Cl)
+    {
+      if(!std.is_fn(Cl)) throw "Invalid or no constructor specified";
+      this.services[name] = Cl;
+    }
+  };
+
+
+  /**
+   * @class
+   * */
+  translation.Service = function () {};
+  translation.Service.prototype.detect = std.absm_noti;
+  translation.Service.prototype.translate = std.absm_noti;
+
+  translation.Service.DEFAULT_TARGET = 'en';
+
+
+  /**
+   * @class
+   * */
+  translation.ServiceGoogle = function (options)
+  {
+    if(!std.is_str(options.key) || options.key.length === 0)
+      throw "API key not specified";
+    this.key = options.key;
+    this.useJsonp = options.useJsonp === true;
+  };
+  translation.Factory.register('google', translation.ServiceGoogle);
+
+  translation.ServiceGoogle.URL_BASE
+    = 'https://www.googleapis.com/language/translate/v2';
+
+  translation.ServiceGoogle.prototype
+    = Object.create(translation.Service.prototype);
+
+  translation.ServiceGoogle.prototype.url = function (query, endpoint)
+  {
+    var url = translation.ServiceGoogle.URL_BASE;
+    if(endpoint) url += '/' + endpoint;
+    return url + '?key=' + this.key + '&q=' + encodeURIComponent(query);
+  };
+
+  translation.ServiceGoogle.prototype.query = function (url)
+  {
+    return $.ajax( { url: url, dataType: this.useJsonp ? "jsonp" : "json" } );
+  };
+
+  translation.ServiceGoogle.prototype.detect = function (query)
+  {
+    var url = this.url(query, 'detect');
+    return this.query(url).then(function (response) {
+      return $.Deferred(function (deferred) {
+        if(!std.is_obj(response.data)
+           || !std.is_arr(response.data.detections)
+           || response.data.detections.length === 0
+           || response.data.detections[0].length === 0) {
+          deferred.reject();
+        }
+
+        response.data.detections[0].sort(function (l, r) {
+          if(l.confidence < r.confidence)      return -1;
+          else if(l.confidence > r.confidence) return 1;
+          return 0;
+        } );
+
+        deferred.resolve(response.data.detections[0][0].language);
+      } ).promise();
+    } );
+  };
+
+  translation.ServiceGoogle.prototype.translate
+    = function (query, /* optional */ tgt, src)
+  {
+    var self = this;
+
+    if(!std.is_str(tgt)) tgt = translation.Service.DEFAULT_TARGET;
+
+    if(!std.is_str(src)) {
+      return this.detect(query)
+        .then(function (src) { return self.translateEx(query, tgt, src); } );
+    }
+
+    return this.translateEx(query, tgt, src);
+  };
+
+  translation.ServiceGoogle.prototype.translateEx = function (query, tgt, src)
+  {
+    var url = this.url(query);
+
+    if(!std.is_str(src))      throw "Invalid or no source language specified";
+    else if(!std.is_str(tgt)) throw "Invalid or no target language specified";
+    url += '&source=' + src + '&target=' + tgt;
+
+    return this.query(url).then(function (response) {
+      return $.Deferred(function (deferred) {
+        if(!std.is_obj(response.data)
+           || !std.is_arr(response.data.translations)
+           || response.data.translations.length === 0) {
+          deferred.reject();
+        }
+
+        deferred.resolve(response.data.translations[0].translatedText);
+      } ).promise();
+    } );
+  };
+
+
+  /**
+   * @class
+   * */
+  translation.Controller = function (explorer, callbacks, options)
+  {
+    std.Controller.call(this, explorer);
+
+    this.processing = false;
+    this.$button = options.button;
+    this.explorer = explorer;
+    this.callbacks = callbacks;
+
+    try {
+      this.service = std.is_obj(options.service)
+        ? translation.Factory.construct(options.service)
+        : null;
+    } catch(x) { console.info("Translation service unavailable"); }
+  };
+
+  translation.Controller.prototype = Object.create(std.Controller.prototype);
+
+  translation.Controller.prototype.initialise = function ()
+  {
+    if(!this.service) {
+      this.$button.addClass('disabled');
+      return;
+    }
+
+    this.$button.on("click", this.onClick.bind(this));
+  };
+
+  translation.Controller.prototype.reset = function ()
+  {
+    this.processing = false;
+    this.$button.off("click");
+    this.$button = this.service = null;
+  };
+
+  translation.Controller.prototype.onClick = function ()
+  {
+    var subfolder = this.explorer.selected;
+
+    if(this.processing) return;
+    else if(!(subfolder instanceof sd.Subfolder)) {
+      window.alert("Please select a subfolder to add the translated"
+                   + " text item to.");
+      return;
+    }
+
+    this.$button.addClass('disabled');
+    this.processing = true;
+
+    var self = this;
+    this.explorer.get_selection_().done(function (selection) {
+      if(selection.type !== "text") {
+        console.info("Selection type not supported: %s", selection.type);
+        self.enable_();
+        return;
+      }
+
+      console.info("Translating: ", selection.content);
+      self.service.translate(selection.content)
+        .done(function (response) {
+          console.log("All ok!: ", response);
+          selection.content = response;
+          return;
+          subfolder.add(selection);
+        } )
+        .fail(function () {
+          window.alert("Text translation failed.");
+          console.error("Translation failed");
+        } )
+        .always(function () { self.enable_(); } );
+    } ).always(function () { self.enable_(); } );
+  };
+
+  translation.Controller.prototype.enable_ = function ()
+  {
+    this.processing = false;
+    this.$button.removeClass('disabled');
+  };
+
+
+  return translation;
+
+}, this);

--- a/src/browser/extensions/firefox/data/src/html/sidebar.html
+++ b/src/browser/extensions/firefox/data/src/html/sidebar.html
@@ -25,6 +25,7 @@
   <!-- Sorting Desk -->
   <script src="../../lib/sorting-desk/api-live.js"></script>
   <script src="../../lib/sorting-desk/sorting_desk.js"></script>
+  <script src="../../lib/sorting-desk/translation.js"></script>
   <!-- Sorting Desk: components -->
   <script src="../js/sidebar.js"></script>
 
@@ -83,6 +84,11 @@
           </button>
           <button type="button" class="btn btn-default disabled" data-toggle="tooltip" data-placement="bottom" title="Navigate to bookmarked page" data-sd-scope="sorting-desk-toolbar-jump">
             <span class="glyphicon glyphicon-eye-open"></span>
+          </button>
+        </div>
+        <div class="btn-group btn-group-xs">
+          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Translate selected text" data-sd-scope="sorting-desk-toolbar-translate">
+            <span class="glyphicon glyphicon-comment"></span>
           </button>
         </div>
         <div class="btn-group btn-group-xs">

--- a/src/browser/extensions/firefox/data/src/js/sidebar.js
+++ b/src/browser/extensions/firefox/data/src/js/sidebar.js
@@ -294,6 +294,11 @@ var Main = (function (window, $, std, sq, sqc, sd, undefined) {
     (sorter = new sd.Sorter( {
       container: $('#sd-folder-explorer'),
       dossierUrl: preferences.dossierUrl,
+      translation: {
+        api: preferences.translation.api,
+        key: preferences.translation.key,
+        useJsonp: true
+      },
       sortingQueue: {
         options: {
           container: $('#sd-queue'),

--- a/src/browser/extensions/firefox/lib/preferences.js
+++ b/src/browser/extensions/firefox/lib/preferences.js
@@ -31,8 +31,12 @@ var Preferences = (function () {
   var get = function () {
     return {
       dossierUrl: activeUrl_,
-      active: prefs.active
-    }
+      active: prefs.active,
+      translation: {
+        api: prefs.translationApi,
+        key: prefs.translationKey
+      }
+    };
   };
 
   var getDossierUrl = function () {

--- a/src/browser/extensions/firefox/lib/preferences.js
+++ b/src/browser/extensions/firefox/lib/preferences.js
@@ -91,36 +91,39 @@ var Preferences = (function () {
     return urls.join(', ');
   };
 
-  var timedSetDossierUrl_ = function (name, delay)
+  var timedSetDossierUrl_ = function ()
   {
-    if(timerSet_ !== null)
-      mtimers.clearTimeout(timerSet_);
-
+    if(timerSet_ !== null) mtimers.clearTimeout(timerSet_);
     timerSet_ = mtimers.setTimeout(function () {
-      activeUrl_ = dossierUrls_[name];
-      mmain.onUrlUpdated(activeUrl_);
+      activeUrl_ = dossierUrls_[prefs.urlName];
+      mmain.onPreferencesChanged();
       timerSet_ = null;
-    }, delay === undefined ? 1500 : delay);
+    }, 1500);
   };
 
-  var timedUpdate_ = function ()
+  var timedUpdate_ = function (delay)
   {
-    if(timerUpdate_ !== null)
-      mtimers.clearTimeout(timerUpdate_);
-
+    if(timerUpdate_ !== null) mtimers.clearTimeout(timerUpdate_);
     timerUpdate_ = mtimers.setTimeout(function () {
-      updateDossierUrls_();
+      update_();
       timerUpdate_ = null;
-    }, 2500);
+    }, delay || 1500);
   };
+
+  var update_ = function ()
+  {
+    var url = prefs.urlName;
+    updateDossierUrls_();
+    mmain.onPreferencesChanged();
+  };
+
 
   /* Initialisation sequence */
-  mprefs.on('active',      function () { mmain.toggle(prefs.active); } );
-  mprefs.on('dossierUrls', function () { timedUpdate_(); } );
-
-  mprefs.on('urlName', function () {
-    timedSetDossierUrl_(prefs.urlName);
-  } );
+  mprefs.on('active',         function () { mmain.onSetActive(prefs.active);});
+  mprefs.on('dossierUrls',    function () { timedUpdate_(2000); } );
+  mprefs.on('urlName',        timedSetDossierUrl_);
+  mprefs.on('translationApi', function () { timedUpdate_(); } );
+  mprefs.on('translationKey', function () { timedUpdate_(); } );
 
   updateDossierUrls_();
   activeUrl_ = dossierUrls_[prefs.urlName];

--- a/src/browser/extensions/firefox/package.json
+++ b/src/browser/extensions/firefox/package.json
@@ -46,6 +46,13 @@
       "description": "Paste the translation API key here.",
       "type": "string",
       "value": ""
+    },
+    {
+      "name": "active",
+      "title": "Sorting Desk active",
+      "description": "Check to construct the Sorting Desk sidebar.",
+      "type": "bool",
+      "value": true
     }
   ]
 }

--- a/src/browser/extensions/firefox/package.json
+++ b/src/browser/extensions/firefox/package.json
@@ -28,11 +28,24 @@
       "value": "memex"
     },
     {
-      "name": "active",
-      "title": "Sorting Desk active",
-      "description": "Check to activate Sorting Desk",
-      "type": "bool",
-      "value": true
+      "name": "translationApi",
+      "title": "Translation API service",
+      "description": "Select the translation service you would like to use.",
+      "type": "menulist",
+      "value": "google",
+      "options": [
+        {
+          "value": "google",
+          "label": "Google Translate"
+        }
+      ]
+    },
+    {
+      "name": "translationKey",
+      "title": "Translation API key",
+      "description": "Paste the translation API key here.",
+      "type": "string",
+      "value": ""
     }
   ]
 }

--- a/src/sorting-desk/sorting_desk.js
+++ b/src/sorting-desk/sorting_desk.js
@@ -2727,7 +2727,11 @@
   return {
     Sorter: Sorter,
     ControllerExplorer: ControllerExplorer,
-    NetworkFailure: NetworkFailure
+    NetworkFailure: NetworkFailure,
+    Folder: Folder,
+    Subfolder: Subfolder,
+    ItemText: ItemText,
+    ItemImage: ItemImage
   };
 
 }, this);

--- a/src/sorting-desk/sorting_desk.js
+++ b/src/sorting-desk/sorting_desk.js
@@ -1,5 +1,5 @@
 /**
- * @file Sorting Desk component.
+ * @file Sorting Desk main component.
  * @copyright 2015 Diffeo
  *
  * Comments:
@@ -134,6 +134,7 @@
     get constructor ()   { return this.constructor_; },
     get callbacks ()     { return this.callbacks_; },
     get networkFailure() { return this.networkFailure_; },
+    get translator()     { return this.translator_; },
     get events ()        { return this.events_; },
     get api ()           { return this.api_; },
     get resetting ()     { return this.sortingQueue_.resetting(); },
@@ -180,6 +181,7 @@
           remove: finder.find('toolbar-remove'),
           rename: finder.find('toolbar-rename'),
           jump: finder.find('toolbar-jump'),
+          translate: finder.find('toolbar-translate'),
           refresh: {
             explorer: finder.find('toolbar-refresh-explorer'),
             search: finder.find('toolbar-refresh-search')
@@ -228,6 +230,14 @@
                                this.callbacks_,
                                this.options.renderer);
 
+      (this.translator_ = new translation.Controller(
+        this.explorer_,
+        this.callbacks_,
+        {
+          button: els.toolbar.translate,
+          service: this.options.translation
+        } )).initialise();
+
       this.initialised_ = true;
       console.info("Sorting Desk UI initialised");
     },
@@ -245,10 +255,12 @@
       var self = this;
 
       this.explorer_.reset();
+      this.translator_.reset();
 
       return this.sortingQueue_.reset()
         .done(function () {
           self.explorer_ = self.options_ = self.sortingQueue_ = null;
+          self.translator_ = null;
           self.initialised_ = false;
 
           console.info("Sorting Desk UI reset");

--- a/src/sorting-desk/sorting_desk.js
+++ b/src/sorting-desk/sorting_desk.js
@@ -1362,7 +1362,7 @@
         deferred.reject();
       else
         deferred.resolve(result);
-    } );
+    } ).fail(function () { deferred.reject(); } );
 
     return deferred.promise();
   };

--- a/src/sorting-desk/translation.js
+++ b/src/sorting-desk/translation.js
@@ -216,7 +216,7 @@
       console.info("Translating: ", selection.content);
       self.service.translate(selection.content)
         .done(function (response) {
-          console.log("All ok!: ", response);
+          console.log("Translation: ", response);
           selection.content = response;
           subfolder.add(selection);
         } )
@@ -225,6 +225,9 @@
           console.error("Translation failed");
         } )
         .always(function () { self.enable_(); } );
+    } ).fail(function () {
+      window.alert("Unable to translate text.  Please ensure text is currently"
+                   + " selected in the active tab");
     } ).always(function () { self.enable_(); } );
   };
 

--- a/src/sorting-desk/translation.js
+++ b/src/sorting-desk/translation.js
@@ -71,6 +71,7 @@
     if(!std.is_str(options.key) || options.key.length === 0)
       throw "API key not specified";
     this.key = options.key;
+    this.useJsonp = options.useJsonp === true;
   };
   translation.Factory.register('google', translation.ServiceGoogle);
 
@@ -87,10 +88,15 @@
     return url + '?key=' + this.key + '&q=' + encodeURIComponent(query);
   };
 
+  translation.ServiceGoogle.prototype.query = function (url)
+  {
+    return $.ajax( { url: url, dataType: this.useJsonp ? "jsonp" : "json" } );
+  };
+
   translation.ServiceGoogle.prototype.detect = function (query)
   {
     var url = this.url(query, 'detect');
-    return $.getJSON(url).then(function (response) {
+    return this.query(url).then(function (response) {
       return $.Deferred(function (deferred) {
         if(!std.is_obj(response.data)
            || !std.is_arr(response.data.detections)
@@ -133,7 +139,7 @@
     else if(!std.is_str(tgt)) throw "Invalid or no target language specified";
     url += '&source=' + src + '&target=' + tgt;
 
-    return $.getJSON(url).then(function (response) {
+    return this.query(url).then(function (response) {
       return $.Deferred(function (deferred) {
         if(!std.is_obj(response.data)
            || !std.is_arr(response.data.translations)

--- a/src/sorting-desk/translation.js
+++ b/src/sorting-desk/translation.js
@@ -1,0 +1,234 @@
+/**
+ * @file Translation component.
+ * @copyright 2015 Diffeo
+ *
+ * Comments:
+ * Uses the `SortingCommon´ component.
+ *
+ */
+
+
+/*global $, define */
+/*jshint laxbreak:true */
+
+
+(function (factory, root) {
+
+  /* Compatibility with RequireJs. */
+  if(typeof define === "function" && define.amd) {
+    var deps = [ "jquery", "SortingCommon", "SortingDesk" ];
+    define("sorting_desk-translation", deps, function ($, std, sd) {
+      return factory(root, $, std, sd);
+    } );
+  } else
+    root.translation = factory(root, $, SortingCommon, SortingDesk);
+
+} )(function (window, $, std, sd, undefined) {
+
+
+  /* component namespace */
+  var translation = { };
+
+
+  /**
+   * @class
+   * */
+  translation.Factory = {
+    services: {},
+
+    construct: function (options)
+    {
+      var Cl = this.services[options.api];
+      if(!std.is_fn(Cl))
+        throw "Invalid, no API name specified or API not found";
+
+      return new Cl(options);
+    },
+
+    register: function (name, Cl)
+    {
+      if(!std.is_fn(Cl)) throw "Invalid or no constructor specified";
+      this.services[name] = Cl;
+    }
+  };
+
+
+  /**
+   * @class
+   * */
+  translation.Service = function () {};
+  translation.Service.prototype.detect = std.absm_noti;
+  translation.Service.prototype.translate = std.absm_noti;
+
+  translation.Service.DEFAULT_TARGET = 'en';
+
+
+  /**
+   * @class
+   * */
+  translation.ServiceGoogle = function (options)
+  {
+    if(!std.is_str(options.key) || options.key.length === 0)
+      throw "API key not specified";
+    this.key = options.key;
+  };
+  translation.Factory.register('google', translation.ServiceGoogle);
+
+  translation.ServiceGoogle.URL_BASE
+    = 'https://www.googleapis.com/language/translate/v2';
+
+  translation.ServiceGoogle.prototype
+    = Object.create(translation.Service.prototype);
+
+  translation.ServiceGoogle.prototype.url = function (query, endpoint)
+  {
+    var url = translation.ServiceGoogle.URL_BASE;
+    if(endpoint) url += '/' + endpoint;
+    return url + '?key=' + this.key + '&q=' + encodeURIComponent(query);
+  };
+
+  translation.ServiceGoogle.prototype.detect = function (query)
+  {
+    var url = this.url(query, 'detect');
+    return $.getJSON(url).then(function (response) {
+      return $.Deferred(function (deferred) {
+        if(!std.is_obj(response.data)
+           || !std.is_arr(response.data.detections)
+           || response.data.detections.length === 0
+           || response.data.detections[0].length === 0) {
+          deferred.reject();
+        }
+
+        response.data.detections[0].sort(function (l, r) {
+          if(l.confidence < r.confidence)      return -1;
+          else if(l.confidence > r.confidence) return 1;
+          return 0;
+        } );
+
+        deferred.resolve(response.data.detections[0][0].language);
+      } ).promise();
+    } );
+  };
+
+  translation.ServiceGoogle.prototype.translate
+    = function (query, /* optional */ tgt, src)
+  {
+    var self = this;
+
+    if(!std.is_str(tgt)) tgt = translation.Service.DEFAULT_TARGET;
+
+    if(!std.is_str(src)) {
+      return this.detect(query)
+        .then(function (src) { return self.translateEx(query, tgt, src); } );
+    }
+
+    return this.translateEx(query, tgt, src);
+  };
+
+  translation.ServiceGoogle.prototype.translateEx = function (query, tgt, src)
+  {
+    var url = this.url(query);
+
+    if(!std.is_str(src))      throw "Invalid or no source language specified";
+    else if(!std.is_str(tgt)) throw "Invalid or no target language specified";
+    url += '&source=' + src + '&target=' + tgt;
+
+    return $.getJSON(url).then(function (response) {
+      return $.Deferred(function (deferred) {
+        if(!std.is_obj(response.data)
+           || !std.is_arr(response.data.translations)
+           || response.data.translations.length === 0) {
+          deferred.reject();
+        }
+
+        deferred.resolve(response.data.translations[0].translatedText);
+      } ).promise();
+    } );
+  };
+
+
+  /**
+   * @class
+   * */
+  translation.Controller = function (explorer, callbacks, options)
+  {
+    std.Controller.call(this, explorer);
+
+    this.processing = false;
+    this.$button = options.button;
+    this.explorer = explorer;
+    this.callbacks = callbacks;
+
+    try {
+      this.service = std.is_obj(options.service)
+        ? translation.Factory.construct(options.service)
+        : null;
+    } catch(x) { console.info("Translation service unavailable"); }
+  };
+
+  translation.Controller.prototype = Object.create(std.Controller.prototype);
+
+  translation.Controller.prototype.initialise = function ()
+  {
+    if(!this.service) {
+      this.$button.addClass('disabled');
+      return;
+    }
+
+    this.$button.on("click", this.onClick.bind(this));
+  };
+
+  translation.Controller.prototype.reset = function ()
+  {
+    this.processing = false;
+    this.$button.off("click");
+    this.$button = this.service = null;
+  };
+
+  translation.Controller.prototype.onClick = function ()
+  {
+    var subfolder = this.explorer.selected;
+
+    if(this.processing) return;
+    else if(!(subfolder instanceof sd.Subfolder)) {
+      window.alert("Please select a subfolder to add the translated"
+                   + " text item to.");
+      return;
+    }
+
+    this.$button.addClass('disabled');
+    this.processing = true;
+
+    var self = this;
+    this.explorer.get_selection_().done(function (selection) {
+      if(selection.type !== "text") {
+        console.info("Selection type not supported: %s", selection.type);
+        self.enable_();
+        return;
+      }
+
+      console.info("Translating: ", selection.content);
+      self.service.translate(selection.content)
+        .done(function (response) {
+          console.log("All ok!: ", response);
+          selection.content = response;
+          subfolder.add(selection);
+        } )
+        .fail(function () {
+          window.alert("Text translation failed.");
+          console.error("Translation failed");
+        } )
+        .always(function () { self.enable_(); } );
+    } ).always(function () { self.enable_(); } );
+  };
+
+  translation.Controller.prototype.enable_ = function ()
+  {
+    this.processing = false;
+    this.$button.removeClass('disabled');
+  };
+
+
+  return translation;
+
+}, this);


### PR DESCRIPTION
### Implemented translation of selected text snippets

Further work required to enable/disable the translation toolbar button depending on whether a text selection exists; currently the button is always enabled.  This will require substantial refactoring of [Sorting Desk](https://trello.com/c/70z82Uqo/86-sd-q-refactoring) (items #11,12,14)

The translation service is made available after it has been suitably configured.  Configuring the translation service can be achieved by accessing the extension's options/preferences window (for Chrome and Firefox, respectively) and selecting the desired translation service and pasting the API key string.  Presently only the Google Translate service is available.

### Miscellaneous
* Improvements to Firefox extension sidebar 
* Several improvements to Firefox extension preferences page